### PR TITLE
fix(node): fix end point in node range

### DIFF
--- a/src/node.zig
+++ b/src/node.zig
@@ -128,7 +128,7 @@ pub const Node = extern struct {
             .start_byte = self.startByte(),
             .end_byte = self.endByte(),
             .start_point = self.startPoint(),
-            .end_point = self.startPoint()
+            .end_point = self.endPoint()
         };
     }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -203,10 +203,11 @@ test "Node" {
     try testing.expectEqual(0, node.startPoint().column);
     try testing.expectEqual(13, node.endPoint().column);
 
-    try testing.expectEqual(node.startByte(), node.range().start_byte);
-    try testing.expectEqual(node.endByte(), node.range().end_byte);
-    try testing.expectEqual(node.startPoint(), node.range().start_point);
-    try testing.expectEqual(node.endPoint(), node.range().end_point);
+    const range = node.range();
+    try testing.expectEqual(0, range.start_byte);
+    try testing.expectEqual(13, range.end_byte);
+    try testing.expectEqual(ts.Point{.row = 0, .column = 0}, range.start_point);
+    try testing.expectEqual(ts.Point{.row = 0, .column = 13}, range.end_point);
 
     try testing.expectEqual(1, node.childCount());
     try testing.expectEqual(1, node.namedChildCount());

--- a/src/test.zig
+++ b/src/test.zig
@@ -203,6 +203,11 @@ test "Node" {
     try testing.expectEqual(0, node.startPoint().column);
     try testing.expectEqual(13, node.endPoint().column);
 
+    try testing.expectEqual(node.startByte(), node.range().start_byte);
+    try testing.expectEqual(node.endByte(), node.range().end_byte);
+    try testing.expectEqual(node.startPoint(), node.range().start_point);
+    try testing.expectEqual(node.endPoint(), node.range().end_point);
+
     try testing.expectEqual(1, node.childCount());
     try testing.expectEqual(1, node.namedChildCount());
     try testing.expectEqual(11, node.descendantCount());

--- a/src/test.zig
+++ b/src/test.zig
@@ -206,8 +206,8 @@ test "Node" {
     const range = node.range();
     try testing.expectEqual(0, range.start_byte);
     try testing.expectEqual(13, range.end_byte);
-    try testing.expectEqual(ts.Point{.row = 0, .column = 0}, range.start_point);
-    try testing.expectEqual(ts.Point{.row = 0, .column = 13}, range.end_point);
+    try testing.expectEqual(0, range.start_point.column);
+    try testing.expectEqual(13, range.end_point.column);
 
     try testing.expectEqual(1, node.childCount());
     try testing.expectEqual(1, node.namedChildCount());


### PR DESCRIPTION
Hello,

This PR fixes a bug in `Node.range()` and adds related test.

Let me know if something else is needed for this PR.