### PR TITLE
feat!: update API to match core

### DIFF
--- a/src/alloc.zig
+++ b/src/alloc.zig
@@ -16,5 +16,5 @@ pub extern fn ts_set_allocator(
     new_malloc: ?*const fn (size: usize) callconv(.C) ?*anyopaque,
     new_calloc: ?*const fn (nmemb: usize, size: usize) callconv(.C) ?*anyopaque,
     new_realloc: ?*const fn (ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque,
-    new_free: ?*const fn (ptr: ?*anyopaque) callconv(.C) void
+    new_free: ?*const fn (ptr: ?*anyopaque) callconv(.C) void,
 ) void;

--- a/src/query.zig
+++ b/src/query.zig
@@ -30,16 +30,16 @@ pub const Query = opaque {
     /// ```
     pub fn create(language: *const Language, source: []const u8, error_offset: *u32) Error!*Query {
         var error_type: QueryError = .None;
-        return ts_query_new(language, source.ptr, @intCast(source.len), error_offset, &error_type)
-            orelse switch (error_type) {
-                .Syntax => error.InvalidSyntax,
-                .NodeType => error.InvalidNodeType,
-                .Field => error.InvalidField,
-                .Capture => error.InvalidCapture,
-                .Structure => error.InvalidStructure,
-                .Language => error.InvalidLanguage,
-                else => unreachable,
-            };
+        const query = ts_query_new(language, source.ptr, @intCast(source.len), error_offset, &error_type);
+        return query orelse switch (error_type) {
+            .Syntax => error.InvalidSyntax,
+            .NodeType => error.InvalidNodeType,
+            .Field => error.InvalidField,
+            .Capture => error.InvalidCapture,
+            .Structure => error.InvalidStructure,
+            .Language => error.InvalidLanguage,
+            else => unreachable,
+        };
     }
 
     /// Delete the query, freeing all of the memory that it used.
@@ -146,7 +146,7 @@ pub const Query = opaque {
     }
 
     /// The kind of error that occurred while creating a `Query`.
-    pub const Error = error {
+    pub const Error = error{
         InvalidSyntax,
         InvalidNodeType,
         InvalidField,
@@ -194,8 +194,13 @@ pub const Query = opaque {
     };
 };
 
-extern fn ts_query_new(language: ?*const Language, source: [*c]const u8, source_len: u32,
-                       error_offset: *u32, error_type: *QueryError) ?*Query;
+extern fn ts_query_new(
+    language: ?*const Language,
+    source: [*c]const u8,
+    source_len: u32,
+    error_offset: *u32,
+    error_type: *QueryError,
+) ?*Query;
 extern fn ts_query_delete(self: *Query) void;
 extern fn ts_query_pattern_count(self: *const Query) u32;
 extern fn ts_query_capture_count(self: *const Query) u32;
@@ -206,10 +211,16 @@ extern fn ts_query_is_pattern_rooted(self: *const Query, pattern_index: u32) boo
 extern fn ts_query_is_pattern_non_local(self: *const Query, pattern_index: u32) bool;
 extern fn ts_query_is_pattern_guaranteed_at_step(self: *const Query, byte_offset: u32) bool;
 extern fn ts_query_capture_name_for_id(self: *const Query, index: u32, length: *u32) [*c]const u8;
-extern fn ts_query_capture_quantifier_for_id(self: *const Query, pattern_index: u32,
-                                             capture_index: u32) Query.Quantifier;
+extern fn ts_query_capture_quantifier_for_id(
+    self: *const Query,
+    pattern_index: u32,
+    capture_index: u32,
+) Query.Quantifier;
 extern fn ts_query_string_value_for_id(self: *const Query, index: u32, length: *u32) [*c]const u8;
 extern fn ts_query_disable_capture(self: *Query, name: [*c]const u8, length: u32) void;
 extern fn ts_query_disable_pattern(self: *Query, pattern_index: u32) void;
-extern fn ts_query_predicates_for_pattern(self: *const Query, pattern_index: u32,
-                                          step_count: *u32) [*c]const Query.PredicateStep;
+extern fn ts_query_predicates_for_pattern(
+    self: *const Query,
+    pattern_index: u32,
+    step_count: *u32,
+) [*c]const Query.PredicateStep;

--- a/src/root.zig
+++ b/src/root.zig
@@ -4,7 +4,7 @@
 ///
 /// The Tree-sitter library is generally backwards-compatible with
 /// languages generated using older CLI versions, but is not forwards-compatible.
-pub const LANGUAGE_VERSION = 14;
+pub const LANGUAGE_VERSION = 15;
 
 /// The earliest ABI version that is supported by the current version of the library.
 pub const MIN_COMPATIBLE_LANGUAGE_VERSION = 13;

--- a/src/tree.zig
+++ b/src/tree.zig
@@ -43,7 +43,7 @@ pub const Tree = opaque {
     pub fn getIncludedRanges(self: *const Tree) []const Range {
         var length: u32 = 0;
         const ranges = ts_tree_included_ranges(self, &length);
-        return ranges[0..length];
+        return if (length > 0) ranges[0..length] else &.{};
     }
 
     /// Compare an old edited syntax tree to a new syntax
@@ -53,11 +53,16 @@ pub const Tree = opaque {
     /// For this to work correctly, this tree must have been
     /// edited such that its ranges match up to the new tree.
     ///
+    /// The returned ranges indicate areas where the hierarchical
+    /// structure of syntax nodes (from root to leaf) has changed
+    /// between the old and new trees. Characters outside these
+    /// ranges have identical ancestor nodes in both trees.
+    ///
     /// The caller is responsible for freeing them using `freeRanges()`.
     pub fn getChangedRanges(self: *const Tree, new_tree: *const Tree) []const Range {
         var length: u32 = 0;
         const ranges = ts_tree_get_changed_ranges(self, new_tree, &length);
-        return ranges[0..length];
+        return if (length > 0) ranges[0..length] else &.{};
     }
 
     /// Free the ranges allocated with `getIncludedRanges()` or `getChangedRanges()`.

--- a/src/tree_cursor.zig
+++ b/src/tree_cursor.zig
@@ -16,6 +16,9 @@ pub const TreeCursor = extern struct {
     context: [3]u32,
 
     /// Create a new tree cursor starting from the given node.
+    ///
+    /// Note that the given node is considered the root of the
+    /// cursor, so the cursor cannot walk outside this node.
     pub inline fn create(node: Node) TreeCursor {
         return ts_tree_cursor_new(node);
     }
@@ -108,8 +111,8 @@ pub const TreeCursor = extern struct {
         return ts_tree_cursor_goto_descendant(self, index);
     }
 
-    /// Move the cursor to the first child of its current
-    /// node that extends beyond the given byte offset.
+    /// Move the cursor to the first child of its current node
+    /// that contains or starts after the given byte offset.
     ///
     /// This returns the index of the child node if one was found, or `null`.
     pub inline fn gotoFirstChildForByte(self: *TreeCursor, byte: u32) ?u32 {
@@ -117,8 +120,8 @@ pub const TreeCursor = extern struct {
         return if (index >= 0) @intCast(index) else null;
     }
 
-    /// Move the cursor to the first child of its current
-    /// node that extends beyond the given point.
+    /// Move the cursor to the first child of its current node
+    /// that contains or starts after the given point.
     ///
     /// This returns the index of the child node if one was found, or `null`.
     pub inline fn gotoFirstChildForPoint(self: *TreeCursor, point: Point) ?u32 {

--- a/src/types.zig
+++ b/src/types.zig
@@ -13,10 +13,18 @@ pub const Input = extern struct {
         payload: ?*anyopaque,
         byte_index: u32,
         position: Point,
-        bytes_read: *u32
+        bytes_read: *u32,
     ) callconv(.C) [*c]const u8,
     /// An indication of how the text is encoded.
     encoding: InputEncoding = InputEncoding.UTF_8,
+    // This function reads one code point from the given string, returning
+    /// the number of bytes consumed. It should write the code point to
+    /// the `code_point` pointer, or write `-1` if the input is invalid.
+    decode: ?*const fn (
+        string: [*c]const u8,
+        length: u32,
+        code_point: *i32,
+    ) callconv(.C) u32 = null,
 };
 
 /// An edit to a text document.
@@ -37,7 +45,7 @@ pub const Logger = extern struct {
     log: ?*const fn (
         payload: ?*anyopaque,
         log_type: LogType,
-        buffer: [*:0]const u8
+        buffer: [*:0]const u8,
     ) callconv(.C) void = null,
 };
 
@@ -78,7 +86,9 @@ pub const Range = extern struct {
 /// The encoding of source code.
 pub const InputEncoding = enum(c_uint) {
     UTF_8,
-    UTF_16,
+    UTF_16LE,
+    UTF_16BE,
+    Custom,
 };
 
 /// The type of a log message.


### PR DESCRIPTION
### Additions

- `Input.decode`
- `Language.name()`
- `Language.abi_version()`
- `Language.semantic_version()`
- `Language.subtypes()`
- `Language.supertypes()`
- `Node.firstChildForByte(byte)`
- `Node.firstNamedChildForByte(byte)`
- `Parser.State`
- `Parser.Options`
- `QueryCursor.State`
- `QueryCursor.Options`

### Removals

- `Node.childContainingDescendant(descendant)`

### Changes

- `LANGUAGE_VERSION`
- `InputEncoding`
- `Parser.parseInput()`
- `QueryCursor.exec()`

### Deprecations

- `Language.version()`
- `Parser.getTimeoutMicros()`
- `Parser.setTimeoutMicros(timeout)`
- `Parser.getCancellationFlag()`
- `Parser.setCancellationFlag(flag)`
- `QueryCursor.getTimeoutMicros()`
- `QueryCursor.setTimeoutMicros(timeout)`