### PR TITLE
feat!: update the module for new bindings layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
-    const tree_sitter = b.dependency("tree_sitter", .{
+    const tree_sitter = b.dependency("tree-sitter", .{
         .target = target,
         .optimize = optimize,
     });
-    exe.root_module.addImport("tree_sitter", tree_sitter.module("tree_sitter"));
+    exe.root_module.addImport("tree-sitter", tree_sitter.module("tree-sitter"));
 
     const tree_sitter_zig = b.dependency("tree_sitter_zig", .{
         .target = target,
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) void {
 
 ```zig
 const std = @import("std");
-const ts = @import("tree_sitter");
+const ts = @import("tree-sitter");
 
 extern fn tree_sitter_zig() callconv(.C) *ts.Language;
 

--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) !void {
 
     b.installArtifact(lib);
 
-    const module = b.addModule("tree_sitter", .{
+    const module = b.addModule("tree-sitter", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
@@ -28,7 +28,7 @@ pub fn build(b: *std.Build) !void {
     module.linkLibrary(lib);
 
     const docs = b.addObject(.{
-        .name = "tree_sitter",
+        .name = "tree-sitter",
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = .Debug,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "tree_sitter",
+    .name = "tree-sitter",
 
     .version = "0.24.2",
 

--- a/src/language.zig
+++ b/src/language.zig
@@ -18,22 +18,6 @@ const LanguageFn = *const fn () callconv(.C) *const Language;
 
 /// An opaque object that defines how to parse a particular language.
 pub const Language = opaque {
-    /// Load the given language from a library at compile-time.
-    pub fn load(comptime language_name: [:0]const u8) *const Language {
-        const symbol_name = std.fmt.comptimePrint("tree_sitter_{s}", .{language_name});
-        return @extern(LanguageFn, .{ .name = symbol_name })();
-    }
-
-    /// Load the given language from a library at runtime.
-    ///
-    /// This returns an error if it failed to load the library or find the symbol.
-    pub fn dynLoad(library_path: []const u8, symbol_name: [:0]const u8) error{ LibError, SymError }!*const Language {
-        var library = std.DynLib.open(library_path) catch return error.LibError;
-        defer library.close();
-        const function = library.lookup(LanguageFn, symbol_name) orelse return error.SymError;
-        return function();
-    }
-
     /// Free any dynamically-allocated resources for this language, if this is the last reference.
     pub inline fn destroy(self: *const Language) void {
         ts_language_delete(self);

--- a/src/test.zig
+++ b/src/test.zig
@@ -2,8 +2,10 @@ const std = @import("std");
 const testing = std.testing;
 const ts = @import("root.zig");
 
+extern fn tree_sitter_c() *const ts.Language;
+
 test "Language" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     try testing.expectEqual(14, language.abi_version());
@@ -26,7 +28,7 @@ test "Language" {
 }
 
 test "LookaheadIterator" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const state = language.nextState(1, 161);
@@ -53,7 +55,7 @@ test "LookaheadIterator" {
 }
 
 test "Parser" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const parser = ts.Parser.create();
@@ -72,7 +74,7 @@ test "Parser" {
 }
 
 test "Tree" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const parser = ts.Parser.create();
@@ -121,7 +123,7 @@ test "Tree" {
 }
 
 test "TreeCursor" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const parser = ts.Parser.create();
@@ -172,7 +174,7 @@ test "TreeCursor" {
 }
 
 test "Node" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const parser = ts.Parser.create();
@@ -259,7 +261,7 @@ test "Node" {
 }
 
 test "Query" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     var error_offset: u32 = 0;
@@ -300,7 +302,7 @@ test "Query" {
 }
 
 test "QueryCursor" {
-    const language = ts.Language.load("c");
+    const language = tree_sitter_c();
     defer language.destroy();
 
     const source =


### PR DESCRIPTION
Instead of using dynLoad or load, the grammar repositories will expose a `language` function that is of type `Language`. Additionally, users can declare an extern `tree_sitter_language` fn that returns a `*const Language`, if they don't want to opt into using the grammar's module. Lastly, the module here should be called `tree-sitter`.