### PR TITLE
Update build.zig.zon for zig master/0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
-    const tree_sitter = b.dependency("tree-sitter", .{
+    const tree_sitter = b.dependency("tree_sitter", .{
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const core = b.dependency("tree-sitter", .{
+    const core = b.dependency("tree_sitter", .{
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .lazy = true,
         },
         .tree_sitter = .{
-            .url = "git+https://github.com/nihklas/tree-sitter#46d6596df08d35f23d0980fe47fa0b174212164c",
-            .hash = "tree_sitter-0.25.1-Tw2sR2qyCwB21zHf_WMnd6AvN8ILA_DQNltU-dbXInxv",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#521da2b0a7e8815efbcf1e4b98e5ac16113c5763",
+            .hash = "tree_sitter-0.26.0-Tw2sRze4CwBXko_uJgxJ1MkugKV8iVAQuPLxNRHrcqab",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,15 +1,16 @@
 .{
-    .name = "tree-sitter",
+    .name = .tree_sitter,
+    .fingerprint = 0x841224b47f8817f2,
     .version = "0.25.0",
     .dependencies = .{
-        .@"tree-sitter" = .{
-            .url = "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.25.0.tar.gz",
-            .hash = "1220183ce3f991b63d570dfea3cc995395b63018e5de748937ecaaf3b0417629a439",
-        },
         .@"tree-sitter-c" = .{
             .url = "https://github.com/tree-sitter/tree-sitter-c/archive/refs/tags/v0.23.4.tar.gz",
             .hash = "1220d4c5bfcdbf2fe3b074650f5f827731a1e1d6dfd8a0adbfbbf405e08c5adcab4a",
             .lazy = true,
+        },
+        .tree_sitter = .{
+            .url = "git+https://github.com/nihklas/tree-sitter#46d6596df08d35f23d0980fe47fa0b174212164c",
+            .hash = "tree_sitter-0.25.1-Tw2sR2qyCwB21zHf_WMnd6AvN8ILA_DQNltU-dbXInxv",
         },
     },
     .paths = .{


### PR DESCRIPTION
In a recently landed change (https://github.com/ziglang/zig/pull/22994), the structure of the build.zig.zon file changed. This PR fixes the structure to be compatible with the newest master build and coming 0.14 release.

Currently, the package of upstream tree-sitter points to my fork of it with the same fix. When the upstream package fixed it (https://github.com/tree-sitter/tree-sitter/pull/4258), the package should be updated. For that reason, this PR can only be merged after tree-sitter made it's changes. When that happens I'll update the PR. For now, it can just sit here for other people to see, if they have issues with the newest zig version.