### PR TITLE
Introduce wrappers for ts_set_allocator to use a std.mem.Allocator

### DIFF
--- a/src/alloc.zig
+++ b/src/alloc.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 /// Set the allocation functions used by the library.
 ///
 /// By default, Tree-sitter uses the standard libc allocation functions,
@@ -18,3 +19,110 @@ pub extern fn ts_set_allocator(
     new_realloc: ?*const fn (ptr: ?*anyopaque, size: usize) callconv(.C) ?*anyopaque,
     new_free: ?*const fn (ptr: ?*anyopaque) callconv(.C) void,
 ) void;
+
+var ts_allocator: ?std.mem.Allocator = null;
+
+/// Mapping of allocated pointer lengths.
+var alloc_registry: ?std.AutoHashMap(usize, usize) = null;
+
+var mutex = std.Thread.Mutex{};
+
+fn malloc(size: usize) callconv(.C) ?*anyopaque {
+    mutex.lock();
+    defer mutex.unlock();
+
+    if (ts_allocator.?.alloc(u8, size)) |slice| {
+        alloc_registry.?.put(@intFromPtr(slice.ptr), slice.len) catch {
+            ts_allocator.?.free(slice);
+            return null;
+        };
+
+        return @ptrCast(slice);
+    } else |_| {
+        return null;
+    }
+}
+
+fn calloc(nmemb: usize, size: usize) callconv(.C) ?*anyopaque {
+    mutex.lock();
+    defer mutex.unlock();
+
+    if (ts_allocator.?.alloc(u8, nmemb * size)) |new_mem| {
+        alloc_registry.?.put(@intFromPtr(new_mem.ptr), new_mem.len) catch {
+            ts_allocator.?.free(new_mem);
+            return null;
+        };
+
+        @memset(new_mem, 0);
+
+        return @ptrCast(new_mem);
+    } else |_| {
+        return null;
+    }
+}
+
+fn realloc(maybe_ptr: ?*anyopaque, new_size: usize) callconv(.C) ?*anyopaque {
+    if (maybe_ptr) |old_ptr| {
+        mutex.lock();
+        defer mutex.unlock();
+
+        if (alloc_registry.?.get(@intFromPtr(old_ptr))) |old_size| {
+            var old_mem: []u8 = undefined;
+            old_mem.ptr = @ptrCast(old_ptr);
+            old_mem.len = old_size;
+
+            if (ts_allocator.?.realloc(old_mem, new_size)) |new_mem| {
+                const removed = alloc_registry.?.remove(@intFromPtr(old_ptr));
+                std.debug.assert(removed == true);
+
+                if (new_mem.len == 0) return null; // freed old mem
+
+                alloc_registry.?.put(@intFromPtr(new_mem.ptr), new_mem.len) catch {
+                    ts_allocator.?.free(new_mem);
+                    return null;
+                };
+
+                return @ptrCast(new_mem);
+            } else |_| {
+                return null;
+            }
+        }
+    }
+
+    return malloc(new_size);
+}
+
+fn free(maybe_ptr: ?*anyopaque) callconv(.C) void {
+    mutex.lock();
+    defer mutex.unlock();
+    if (maybe_ptr) |ptr| {
+        if (alloc_registry.?.fetchRemove(@intFromPtr(ptr))) |kv| {
+            var slice: []u8 = undefined;
+            slice.ptr = @ptrCast(ptr);
+            slice.len = kv.value;
+
+            ts_allocator.?.free(slice);
+        }
+    }
+}
+
+/// Wrapper for `ts_set_allocator`. Overrides Tree-sitter's default libc
+/// allocation functions with ones backed by a Zig `std.mem.Allocator`.
+/// The caller is responsible for calling `unsetAllocator` to free
+/// map of stored adress lengths.
+pub fn setAllocator(gpa: std.mem.Allocator) void {
+    alloc_registry = std.AutoHashMap(usize, usize).init(gpa);
+    ts_allocator = gpa;
+    ts_set_allocator(malloc, calloc, realloc, free);
+}
+
+/// Make Tree-sitter switch back to using libc allocation
+/// functions and free stored map of allocated address lengths.
+pub fn unsetAllocator() void {
+    if (alloc_registry != null) {
+        alloc_registry.?.deinit();
+        alloc_registry = null;
+    }
+    ts_allocator = null;
+    ts_set_allocator(null, null, null, null);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -7,11 +7,15 @@ pub const LANGUAGE_VERSION = 15;
 /// The earliest ABI version that is supported by the current version of the library.
 pub const MIN_COMPATIBLE_LANGUAGE_VERSION = 13;
 
+const std = @import("std");
 const language = @import("language.zig");
 const parser = @import("parser.zig");
 const tree = @import("tree.zig");
 
-pub const set_allocator = @import("alloc.zig").ts_set_allocator;
+const alloc = @import("alloc.zig");
+pub const set_allocator = alloc.ts_set_allocator;
+pub const setAllocator = alloc.setAllocator;
+pub const unsetAllocator = alloc.unsetAllocator;
 
 pub const Language = language.Language;
 pub const LanguageMetadata = language.LanguageMetadata;


### PR DESCRIPTION
This pr makes it easy to make Tree-Sitter use a zig `std.mem.Allocator` instead of the default libc functions. Usefull for leak detection if combined with `DebugAllocator`.

- Added setAllocator and unsetAllocator to make Tree-Sitter use a std.mem.Allocator.
- malloc, calloc, realloc, and free wrappers that use the above mentioned Allocator.