### PR TITLE
Fix node's children collectors

### DIFF
--- a/src/language.zig
+++ b/src/language.zig
@@ -122,7 +122,7 @@ pub const Language = opaque {
     }
 
     /// Get the numerical id for the given field name.
-    pub fn fieldIdForName(self: *const Language, field_name: []const u8) u32 {
+    pub fn fieldIdForName(self: *const Language, field_name: []const u8) u16 {
         return ts_language_field_id_for_name(self, field_name.ptr, @intCast(field_name.len));
     }
 


### PR DESCRIPTION
Since they couldn't be compiled and had flawed logic, I didn't try to maintain backward-compatibility.  Their interface now complies better with Zig's norms.

Edit: just realized that this competes with GH-23.