### PR TITLE
Fix import name for tree-sitter module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    exe.root_module.addImport("tree-sitter", tree_sitter.module("tree-sitter"));
+    exe.root_module.addImport("tree-sitter", tree_sitter.module("tree_sitter"));
 
     const tree_sitter_zig = b.dependency("tree_sitter_zig", .{
         .target = target,


### PR DESCRIPTION
module name in [`build.zig.zon`](https://github.com/tree-sitter/zig-tree-sitter/blob/4c5d3a45a9828b8fddd3d59132c4346182fc23b7/build.zig.zon#L2) is 
>     .name = .tree_sitter,

