### PR TITLE
fix: build errors for Node

### DIFF
--- a/src/node.zig
+++ b/src/node.zig
@@ -223,7 +223,7 @@ pub const Node = extern struct {
             result.appendAssumeCapacity(cursor.node());
         }
 
-        return result.toOwnedSlice();
+        return result.toOwnedSlice(allocator);
     }
 
     /// Iterate over this node's named children.
@@ -284,7 +284,7 @@ pub const Node = extern struct {
             }
         }
 
-        return result.toOwnedSlice();
+        return result.toOwnedSlice(allocator);
     }
 
     /// Get this node's immediate parent.

--- a/src/node.zig
+++ b/src/node.zig
@@ -218,9 +218,9 @@ pub const Node = extern struct {
             return try result.toOwnedSlice(allocator);
         }
 
-        try result.append(allocator, cursor.currentNode());
+        try result.append(allocator, cursor.node());
         while (cursor.gotoNextSibling()) {
-            result.appendAssumeCapacity(cursor.currentNode());
+            result.appendAssumeCapacity(cursor.node());
         }
 
         return result.toOwnedSlice();
@@ -241,7 +241,7 @@ pub const Node = extern struct {
         }
 
         while (true) {
-            var node = cursor.currentNode();
+            var node = cursor.node();
             if (node.isNamed()) {
                 result.appendAssumeCapacity(node);
             }
@@ -276,8 +276,8 @@ pub const Node = extern struct {
         }
 
         while (true) {
-            if (cursor.currentFieldId() == field_id) {
-                try result.append(allocator, cursor.currentNode());
+            if (cursor.fieldId() == field_id) {
+                try result.append(allocator, cursor.node());
             }
             if (!cursor.gotoNextSibling()) {
                 break;


### PR DESCRIPTION
There are some calls in `src/node.zig` that don't compile:
1. `currentFieldId()` and `currentNode()` don't exist on `TreeCursor` but `fieldId()` and `node()` do.
2. Some calls to `toOwnedSlice()` do not have an allocator.

The first one seems to be a deliberate change (7f531d3575d7c6304d7b8bf628423db455662456), so maybe you'd prefer I fix method names in `TreeCursor` instead? Let me know! ^-^