### PR TITLE
build: add b.installArtifact(lib);

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,6 +34,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = module,
         .linkage = .static,
     });
+    b.installArtifact(lib);
 
     const install_docs = b.addInstallDirectory(.{
         .source_dir = lib.getEmittedDocs(),


### PR DESCRIPTION
This allows the lib artifact to be linked against in other projects.